### PR TITLE
2: Mark unreferenced features in UI

### DIFF
--- a/Flagsmith.Core/FeatureToggleService.cs
+++ b/Flagsmith.Core/FeatureToggleService.cs
@@ -49,6 +49,11 @@ public class FeatureToggleService : IFeatureToggleService
         return _idProvider.GetFeatureIds().Where(x => !existingFeatures.Contains(x));
     }
 
+    public IEnumerable<string> GetAllFeatureIds()
+    {
+        return _idProvider.GetFeatureIds();
+    }
+
     public async Task UpdateFeatureAsync(string featureKey, bool enabled, string? tenantId = default)
     {
         await _featureStore.UpdateFeatureAsync(featureKey, enabled, tenantId);

--- a/Flagsmith.Core/FlagsmithExtensions.cs
+++ b/Flagsmith.Core/FlagsmithExtensions.cs
@@ -77,6 +77,7 @@ public static class FlagsmithExtensions
                             });
                             
                             api.MapGet("/available-ids", async (IFeatureToggleService service) => await service.GetAvailableFeatureIds());
+                            api.MapGet("/known-ids", (IFeatureToggleService service) => service.GetAllFeatureIds());
                             
                             api.MapPatch(
                                 "/feature-flags/{featureId}",

--- a/Flagsmith.Core/IFeatureToggleService.cs
+++ b/Flagsmith.Core/IFeatureToggleService.cs
@@ -6,6 +6,7 @@ public interface IFeatureToggleService
     Task<IEnumerable<TenantState>> GetTenantStateByFeature(string featureId);
     Task<FeatureFlag?> GetFeature(string featureId);
     Task<IEnumerable<string>> GetAvailableFeatureIds();
+    IEnumerable<string> GetAllFeatureIds();
 
 
     Task UpdateFeatureAsync(string featureKey, bool enabled, string? tenantId = default);

--- a/Flagsmith.Dashboard/src/context/TenantContext.tsx
+++ b/Flagsmith.Dashboard/src/context/TenantContext.tsx
@@ -17,6 +17,8 @@ const FeatureContextProvider = ({ children }: React.PropsWithChildren) => {
 
   const { data: availableIds, refetch: refetchAvailableIds } =
     useFetch<string[]>("api/available-ids");
+  const { data: knownIds, refetch: refetchKnownIds } =
+    useFetch<string[]>("api/known-ids");
 
   const toggleFeature = useDirectFetch<
     void,
@@ -65,9 +67,11 @@ const FeatureContextProvider = ({ children }: React.PropsWithChildren) => {
         bulkCreateMissing: async () => {
           await bulkCreateMissing();
           await refetchAvailableIds();
+          await refetchKnownIds();
           await refetchFeatures();
         },
         availableIds: availableIds || [],
+        knownIds: knownIds || [],
       }}
     >
       {children}

--- a/Flagsmith.Dashboard/src/context/useTenants.ts
+++ b/Flagsmith.Dashboard/src/context/useTenants.ts
@@ -27,6 +27,7 @@ export type FeatureContextType = {
     tenantId?: string
   ) => Promise<void>;
   availableIds: string[];
+  knownIds: string[];
   toggleOverride: (tenantId: string, featureId: string) => Promise<void>;
   bulkCreateMissing: () => Promise<void>;
 };
@@ -36,6 +37,7 @@ export const FeatureContext = React.createContext<FeatureContextType>({
   availableFeatures: [],
   updateFeatureState: () => new Promise((res) => res),
   availableIds: [],
+  knownIds: [],
   toggleOverride: () => new Promise((res) => res),
   bulkCreateMissing: () => new Promise((res) => res),
 });

--- a/Flagsmith.Dashboard/src/main.tsx
+++ b/Flagsmith.Dashboard/src/main.tsx
@@ -1,4 +1,3 @@
-import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import { BrowserRouter, Navigate, Route, Routes } from "react-router";
@@ -9,21 +8,19 @@ import FeatureProviderLayout from "./routes/layouts/FeatureProviderLayout.tsx";
 import TenantDashboard from "./routes/Tenant/TenantDashboard.tsx";
 
 createRoot(document.getElementById("root")!).render(
-  <StrictMode>
-    <BrowserRouter basename="/flagsmith">
-      <Routes>
-        <Route element={<FeatureProviderLayout />}>
-          <Route path="features">
-            <Route index element={<FeatureFlagDashboard />} />
-            <Route path=":featureId" element={<FeatureDetail />} />
-          </Route>
-          <Route path="tenants">
-            <Route index element={<TenantDashboard />} />
-            <Route path=":tenantId" element={<TenantDetail />} />
-          </Route>
-          <Route path="*" element={<Navigate to="/features" />} />
+  <BrowserRouter basename="/flagsmith">
+    <Routes>
+      <Route element={<FeatureProviderLayout />}>
+        <Route path="features">
+          <Route index element={<FeatureFlagDashboard />} />
+          <Route path=":featureId" element={<FeatureDetail />} />
         </Route>
-      </Routes>
-    </BrowserRouter>
-  </StrictMode>
+        <Route path="tenants">
+          <Route index element={<TenantDashboard />} />
+          <Route path=":tenantId" element={<TenantDetail />} />
+        </Route>
+        <Route path="*" element={<Navigate to="/features" />} />
+      </Route>
+    </Routes>
+  </BrowserRouter>
 );

--- a/Flagsmith.Dashboard/src/routes/Feature/FeatureFlagDashboard.tsx
+++ b/Flagsmith.Dashboard/src/routes/Feature/FeatureFlagDashboard.tsx
@@ -12,17 +12,19 @@ import {
   LuCircleX,
   LuSearch,
   LuPlus,
+  LuTriangleAlert,
 } from "react-icons/lu";
 import { useNavigate } from "react-router";
 import { useFeatureContext } from "../../context/useTenants";
 import NavTabs, { NavTab } from "../../components/Tabs";
 import Code from "../../components/Code";
+import Tooltip from "../../components/Tooltip";
 
 const FeatureFlagDashboard = () => {
   const navigate = useNavigate();
   const [searchTerm, setSearchTerm] = React.useState("");
 
-  const { availableFeatures, availableIds, bulkCreateMissing } =
+  const { availableFeatures, availableIds, knownIds, bulkCreateMissing } =
     useFeatureContext();
 
   const flags = availableFeatures?.filter(({ feature }) =>
@@ -67,8 +69,13 @@ const FeatureFlagDashboard = () => {
               <CardHeader className="pb-4">
                 <div className="flex justify-between items-start">
                   <div className="flex-1">
-                    <CardTitle className="text-lg font-semibold mb-1">
-                      {flag.name}
+                    <CardTitle className="text-lg font-semibold mb-1 flex items-center gap-2">
+                      {flag.name}{" "}
+                      {!knownIds.some((id) => id === flag.id) && (
+                        <Tooltip text="This feature does not correspond to any ID configured in the application">
+                          <LuTriangleAlert className="text-yellow-500" />
+                        </Tooltip>
+                      )}
                     </CardTitle>
                     <CardDescription>{flag.description}</CardDescription>
                   </div>

--- a/Flagsmith.Dashboard/src/routes/Tenant/TenantDashboard.tsx
+++ b/Flagsmith.Dashboard/src/routes/Tenant/TenantDashboard.tsx
@@ -80,10 +80,7 @@ const TenantDashboard = () => {
                       <CardDescription>ID: {tenant.id}</CardDescription>
                     </div>
                     <div className="p-2 rounded-full bg-gray-100">
-                      <OrganisationIcon
-                        className="w-6 h-6 text-gray-600"
-                        text={tenant.name}
-                      />
+                      <OrganisationIcon text={tenant.name} />
                     </div>
                   </div>
                 </CardHeader>


### PR DESCRIPTION
Any feature that exists, but does not have a referenced ID within the `IFeatureIdProvider` will have a warning symbol in the UI indicating the feature is unused.

![image](https://github.com/user-attachments/assets/cf561f86-b29b-4059-83e8-c8dd63c68a8b)
